### PR TITLE
Use the same extension as the template for output files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -108,7 +108,8 @@ function plugin(options){
          * the build dir
          */
         if (options.template){
-          files[contentType + '-' + file.id + '.html'] = file;
+          var extension = options.template.split('.').slice(1).pop() || 'html';
+          files[contentType + '-' + file.id + '.' + extension] = file;
         }
 
         // This check is being performed for each entry, it might be done out of this loop


### PR DESCRIPTION
This allows seamless interaction of markdown content stored in contentful with `metalsmith-markdown`
