### PR TITLE
Enabled host configuration from options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ plugin is built on top of the [Contentful JavaScript Client](https://github.com/
           ...,
           "contentful-metalsmith": {
               "accessToken" : "YOUR_CONTENTFUL_ACCESS_TOKEN"
+              "host" : "[cdn|preview].contentful.com"
           },
           ...
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ function plugin(options){
        */
       fileMetadata.contentful.entries = [];
 
-      client = createContentfulClient(options.accessToken, fileMetadata.contentful.space_id),
+      client = createContentfulClient(options.accessToken, fileMetadata.contentful.space_id, options.host),
       query  = _.extend({},
           (fileMetadata.contentful.content_type ? {content_type : fileMetadata.contentful.content_type} : undefined),
           fileMetadata.contentful.filter
@@ -121,11 +121,15 @@ function plugin(options){
       };
     }
 
-    function createContentfulClient(accessToken, spaceId){
-      return contentful.createClient({
+    function createContentfulClient(accessToken, spaceId, host){
+      var options = {
         space : spaceId,
-        accessToken : accessToken
-      });
+        accessToken : accessToken,
+      };
+      if (host) {
+        options.host = host;
+      }
+      return contentful.createClient(options);
     }
   };
 


### PR DESCRIPTION
I needed to enable preview mode and I think it might be useful for others as well.
If a falsy host value is given, the CDN url is used by default.