### PR TITLE
Allow errors when fetching entries to bubble

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ function plugin(options){
     function onErroneousEntriesFetch(done) {
       return function(err) {
         debug('An unexpected error happened while trying to fetch the entries (' + err.message +')');
-        done();
+        done(err);
       };
     }
 


### PR DESCRIPTION
This should cause the plugin to fail when requests to the Contentful API fail.

Fixes #11