### PR TITLE
allow for a custom filename builder fn in config

### DIFF
--- a/docs/source-file-settings.md
+++ b/docs/source-file-settings.md
@@ -148,6 +148,28 @@ E.g.
 
 **Default value:** `${sys.contentType.sys.id}-${sys.id}`
 
+### `entry_filename_builder` *(optional)*
+
+**Use a custom function to generate the filename**
+
+`source/posts-that-need-fancy-filenames.html`
+
+```markdown
+---
+title: test__posts__filenameBuilder
+contentful:
+  content_type: 2wKn6yEnZewu2SCCkus4as
+  entry_filename_builder: aldente
+  entry_template: post.html
+layout: posts.html
+---
+POSTS-CONTENT-FILENAME-BUILDER
+```
+
+In your global configuration, define an object `filenameBuilders` with a property named to match `entity_filename_builder` with a function as its value. This function will be called with the arguments `entry` (the entry being processed) and `fileOptions`. Return the desired filename.
+
+Note that a function cannot be specified in the site configuration if it is stored as JSON; rather you will need to invoke Metalsmith programmatically to use this feature.
+
 ### `entry_id` *(optional)*
 
 **Render a file based on a single entry**

--- a/lib/util.js
+++ b/lib/util.js
@@ -72,6 +72,12 @@ function getFileName (entry, fileOptions, globalOptions) {
   fileOptions = fileOptions || {}
   globalOptions = globalOptions || {}
 
+  // Hand off control if a specified custom filename builder exists.
+  if (fileOptions.entry_filename_builder &&
+      typeof globalOptions.filenameBuilders[fileOptions.entry_filename_builder] === 'function') {
+    return globalOptions.filenameBuilders[fileOptions.entry_filename_builder](entry, fileOptions)
+  }
+
   const extension = fileOptions.use_template_extension
                     ? fileOptions.entry_template.split('.').slice(1).pop()
                     : 'html'

--- a/lib/util.spec.js
+++ b/lib/util.spec.js
@@ -164,3 +164,32 @@ test('util.getFileName - should set notFound key', t => {
   t.is(fileName, 'foo/__not-available__.html')
   t.pass()
 })
+
+test('util.getFileName - should use a custom filename builder if available', t => {
+  const fileName = util.getFileName(
+    {
+      sys: {
+        contentType: {
+          sys: {
+            id: 'foo'
+          }
+        },
+        id: 'bar'
+      }
+    },
+    {
+      entry_filename_builder: 'bazquxer'
+    },
+    {
+      filenameBuilders: {
+        bazquxer () {
+          return 'baz-qux.html'
+        }
+      }
+    }
+  )
+
+  t.is(fileName, 'baz-qux.html')
+  t.pass()
+})
+

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -102,11 +102,11 @@ function validateFileNameForEntry (fileName, entry, regex, options) {
   if (regex.test(fileName)) {
     if (options.throw_errors) {
       throw new Error(
-        `contentful-metalsmith: \'entry_file_pattern\' for entry with id '${entry.sys.id}' could not be resolved`
+        `contentful-metalsmith: 'entry_file_pattern' for entry with id '${entry.sys.id}' could not be resolved`
       )
     } else {
       console.warn(
-        `contentful-metalsmith: \'entry_file_pattern\' for entry with id '${entry.sys.id}' could not be resolved -> falling back to ${fileName}`
+        `contentful-metalsmith: 'entry_file_pattern' for entry with id '${entry.sys.id}' could not be resolved -> falling back to ${fileName}`
       )
     }
   }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,6 +1,7 @@
 import test from 'ava'
 import fs from 'fs'
 import Metalsmith from 'metalsmith'
+import slug from 'slug-component'
 
 const expectedResults = {
   postsCustomFileName: `Down the Rabbit HoleSeven Tips From Ernest Hemingway on How to Write Fiction
@@ -60,7 +61,12 @@ test.serial.cb('e2e - it propagate errors properly', t => {
 test.serial.cb('e2e - it should render all templates properly', t => {
   const metalsmith = createMetalsmith({
     space_id: 'w7sdyslol3fu',
-    access_token: 'baa905fc9cbfab17b1bc0b556a7e17a3e783a2068c9fd6ccf74ba09331357182'
+    access_token: 'baa905fc9cbfab17b1bc0b556a7e17a3e783a2068c9fd6ccf74ba09331357182',
+    filenameBuilders: {
+      aldente (entry) {
+        return `aldente-${slug(entry.fields.title)}.html`
+      }
+    }
   })
 
   metalsmith.build(error => {
@@ -121,8 +127,19 @@ test.serial.cb('e2e - it should render all templates properly', t => {
       fs.readFileSync(`${__dirname}/build/post-down-the-rabbit-hole.html`, { encoding: 'utf8' }),
       expectedResults.posts.downTheRabbitHole
     )
+
     t.is(
       fs.readFileSync(`${__dirname}/build/post-seven-tips-from-ernest-hemingway-on-how-to-write-fiction.html`, { encoding: 'utf8' }),
+      expectedResults.posts.sevenTips
+    )
+
+    t.is(
+      fs.readFileSync(`${__dirname}/build/aldente-seven-tips-from-ernest-hemingway-on-how-to-write-fiction.html`, { encoding: 'utf8' }),
+      expectedResults.posts.sevenTips
+    )
+
+    t.is(
+      fs.readFileSync(`${__dirname}/build/aldente-seven-tips-from-ernest-hemingway-on-how-to-write-fiction.html`, { encoding: 'utf8' }),
       expectedResults.posts.sevenTips
     )
 

--- a/test/src/posts-filename-builder.html
+++ b/test/src/posts-filename-builder.html
@@ -1,0 +1,9 @@
+---
+title: test__posts__filenameBuilder
+contentful:
+  content_type: 2wKn6yEnZewu2SCCkus4as
+  entry_filename_builder: aldente
+  entry_template: post.html
+layout: posts.html
+---
+POSTS-CONTENT-FILENAME-BUILDER


### PR DESCRIPTION
sometimes i want more flexibility for naming built files than what is available in `entry_filename_pattern`

this new feature looks for a source property `entry_filename_builder` and looks for a function in the global configuraiton object's `filenameBuilders` with a matching value. if that function exists, it invokes it and names the file with the result.