### PR TITLE
Adds support for global key, #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ When you use metalsmith using the [cli](https://github.com/metalsmith/metalsmith
       "access_token": "YOUR_CONTENTFUL_ACCESS_TOKEN",
       "space_id": "YOUR_CONTENTFUL_SPACE_ID",
       "entry_key": "_key",
-      "entry_extension": "md"
+      "entry_extension": "md",
+      "contentful": {
+        content_type: "2wKn6yEnZewu2SCCkus4as"
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ When you use metalsmith using the [cli](https://github.com/metalsmith/metalsmith
   "plugins": {
     "contentful-metalsmith": {
       "access_token": "YOUR_CONTENTFUL_ACCESS_TOKEN",
-      "space_id": "YOUR_CONTENTFUL_SPACE_ID"
+      "space_id": "YOUR_CONTENTFUL_SPACE_ID",
+      "entry_key": "_key",
+      "entry_extension": "md"
     }
   }
 }
@@ -52,6 +54,8 @@ metalsmith.use(require('contentful-metalsmith')({ 'access_token' : 'YOUR_CONTENT
 
 - `acccess_token`
 - `space_id`
+- `entry_key`
+- `entry_extension`
 
 You can find the `access_token` and `space_id` in your [app](https://app.contentful.com) at `APIs -> Content delivery API Keys`.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ When you use metalsmith using the [cli](https://github.com/metalsmith/metalsmith
       "entry_key": "_key",
       "entry_extension": "md",
       "contentful": {
-        content_type: "2wKn6yEnZewu2SCCkus4as"
+        "content_type": "2wKn6yEnZewu2SCCkus4as"
       }
     }
   }

--- a/docs/global-settings.md
+++ b/docs/global-settings.md
@@ -13,7 +13,10 @@ You can find these in your [app](https://app.contentful.com) at `APIs -> Content
       "space_id": "YOUR_CONTENTFUL_SPACE_ID",
       "host": "preview.contentful.com",
       "entry_key": "_key",
-      "entry_extension": "md"
+      "entry_extension": "md",
+      "contentful": {
+        content_type: "2wKn6yEnZewu2SCCkus4as"
+      }
     }
   }
 }

--- a/docs/global-settings.md
+++ b/docs/global-settings.md
@@ -11,7 +11,9 @@ You can find these in your [app](https://app.contentful.com) at `APIs -> Content
     "contentful-metalsmith": {
       "access_token" : "YOUR_CONTENTFUL_ACCESS_TOKEN",
       "space_id": "YOUR_CONTENTFUL_SPACE_ID",
-      "host": "preview.contentful.com"
+      "host": "preview.contentful.com",
+      "entry_key": "_key",
+      "entry_extension": "md"
     }
   }
 }
@@ -49,6 +51,16 @@ and change the `host` property to `preview.contentful.com`.
 For using the [Content Delivery API](https://www.contentful.com/developers/docs/references/content-delivery-api/) you can ignore this option, as it is defaulting to **Content Delivery API**.
 
 *Recommended way here is to set the `host` in the `metalsmith.json` or global config and overwrite it if needed in depending source files.*
+
+### `entry_key` *(optional)*
+
+If you want to transform Contentful data into pages you can specify a `entry_key` which will be used to replace the key of all file objects with the stored Contentful key path. You must specify a path to the file as if it was referenced from your `src` directory and exclude the extension. 
+
+For example, if you specify `entry_key`: `_key`, then create a Contentful entry with a `_key` property set to `pages/index` a file will be referenced in Metalsmith with `pages/index.md` (assuming you specify `entry_extension` as `md`)
+
+### `entry_extension` *(optional)*
+
+If you specify `entry_key`, you will need to specify the entry extension for all file keys. This will be appended to the key on Contentful entries that contain the `entry_key`.
 
 ### `filterTransforms` *(optional)*
 

--- a/docs/global-settings.md
+++ b/docs/global-settings.md
@@ -97,7 +97,7 @@ layout: posts.html
 ---
 ```
 
-### [`contentful` *(optional)*](/source-file-settings.md)
+### [`contentful` *(optional)*](source-file-settings.md)
 
 ### `common` *(optional)*
 

--- a/docs/global-settings.md
+++ b/docs/global-settings.md
@@ -97,6 +97,8 @@ layout: posts.html
 ---
 ```
 
+### [`contentful` *(optional)*](/source-file-settings.md)
+
 ### `common` *(optional)*
 
 The results of queries placed in this property will be made available in all templates

--- a/docs/global-settings.md
+++ b/docs/global-settings.md
@@ -15,7 +15,7 @@ You can find these in your [app](https://app.contentful.com) at `APIs -> Content
       "entry_key": "_key",
       "entry_extension": "md",
       "contentful": {
-        content_type: "2wKn6yEnZewu2SCCkus4as"
+        "content_type": "2wKn6yEnZewu2SCCkus4as"
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,23 @@
 const processor = require('./lib/processor')
 
 /**
+ * Handles errors
+ * @param  {Function} done  done callback
+ * @param  {object}   error error object
+ */
+function handleError (done, error) {
+  // friendly error formatting to give
+  // more information in error case by api
+  // -> see error.details
+  done(
+    new Error(`
+      ${error.message}
+      ${error.details ? JSON.stringify(error.details, null, 2) : ''}
+    `)
+  )
+}
+
+/**
  * Plugin function
  *
  * @param {Object|undefined} options
@@ -21,6 +38,16 @@ function plugin (options) {
    */
   return function (files, metalsmith, done) {
     options.metadata = metalsmith.metadata()
+
+    if (!Object.keys(files).length && options.entry_key) {
+      return processor.createFilesFromEntries(options)
+        .then((fileMaps) => {
+          Object.assign(files, fileMaps)
+
+          done()
+        })
+        .catch(handleError.bind(null, done))
+    }
 
     return new Promise(resolve => {
       resolve(Object.keys(files))
@@ -41,17 +68,7 @@ function plugin (options) {
 
       done()
     })
-    .catch((error) => {
-      // friendly error formatting to give
-      // more information in error case by api
-      // -> see error.details
-      done(
-        new Error(`
-          ${error.message}
-          ${error.details ? JSON.stringify(error.details, null, 2) : ''}
-        `)
-      )
-    })
+    .catch(handleError.bind(null, done))
   }
 }
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -117,16 +117,16 @@ function processEntriesForFile (file, entries, options) {
     file.data = { entries, contentTypes }
   }
 
-  if (contentfulOptions.entry_template) {
+  if (contentfulOptions.entry_template || options.entry_key) {
     return entries.reduce((fileMap, entry) => {
       fileMap[ entry._fileName ] = Object.assign({
         // `contents` need to be defined because there
         // might be other plugins that expect it
-        contents: '',
+        contents: options.entry_key ? Buffer.from(entry.fields.contents || '') : '',
         data: entry,
         id: entry.sys.id,
         contentType: contentfulOptions.content_type,
-        layout: contentfulOptions.entry_template,
+        layout: options.entry_key ? entry.fields.layout : contentfulOptions.entry_template,
 
         _fileName: entry._fileName,
         _parentFileName: file._fileName

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -80,6 +80,10 @@ function mapEntriesForFile (entries, file, options) {
   return entries.map(entry => {
     entry._fileName = util.getFileName(entry, file.contentful, options)
 
+    if (options.entry_key) {
+      file._fileName = entry._fileName
+    }
+
     return entry
   })
 }
@@ -125,7 +129,7 @@ function processEntriesForFile (file, entries, options) {
         contents: options.entry_key ? Buffer.from(entry.fields.contents || '') : '',
         data: entry,
         id: entry.sys.id,
-        contentType: contentfulOptions.content_type,
+        contentType: contentfulOptions.content_type || entry.sys.contentType.sys.id,
         layout: options.entry_key ? entry.fields.layout : contentfulOptions.entry_template,
 
         _fileName: entry._fileName,
@@ -137,6 +141,29 @@ function processEntriesForFile (file, entries, options) {
   }
 
   return files
+}
+
+function filterEntries (entries, file, options) {
+  return entries.filter(entry => {
+    return entry.fields && entry.fields[options.entry_key]
+  })
+}
+
+function createFilesFromEntries (options) {
+  const spaceId = options.space_id
+  const accessToken = options.access_token
+  const host = options.host
+
+  const query = util.getEntriesQuery(options.contentful, options.filterTransforms)
+  const file = { contentful: options.contentful }
+
+  const client = getContentfulClient(accessToken, spaceId, host)
+
+  return client.getEntries(query)
+    .then(entries => filterEntries(entries.items, file, options))
+    .then(entries => mapEntriesForFile(entries, file, options))
+    .then(entries => processEntriesForFile(file, entries, options))
+    .then(entries => getCommonContentForSpace(entries, options))
 }
 
 /**
@@ -169,5 +196,6 @@ function processFile (file, options) {
 }
 
 module.exports = {
-  processFile
+  processFile,
+  createFilesFromEntries
 }

--- a/lib/processor.spec.js
+++ b/lib/processor.spec.js
@@ -275,19 +275,22 @@ test('processor.getCommonContentForSpace - load a set of common content', t => {
   })
 })
 
-test.cb('processor.processFile - transform file meta into a new file', t => {
+test.cb('processor.createFilesFromEntries - create new files from global options', t => {
   const options = {
     access_token: 'global-bar',
     host: 'global-baz',
     space_id: 'global-foo',
     entry_key: '_key',
-    entry_extension: 'md'
+    entry_extension: 'md',
+    contentful: {
+      entry_id: 'A96usFSlY4G0W4kwAqswk'
+    }
   }
 
   const entriesToBeReturned = [
     {
       sys: {
-        id: 'bazinga',
+        id: 'A96usFSlY4G0W4kwAqswk',
         contentType: {
           sys: {
             id: 'boing'
@@ -297,7 +300,7 @@ test.cb('processor.processFile - transform file meta into a new file', t => {
       fields: {
         name: 'John Doe',
         _key: 'pages/index',
-        layout: 'home.hbs',
+        layout: 'home.html',
         contents: 'Home Page Content'
       }
     }
@@ -318,13 +321,13 @@ test.cb('processor.processFile - transform file meta into a new file', t => {
     }
   )
 
-  processor.processFile({ contentful: {}, _fileName: 'turnip.html' }, options)
-  .then(fileMap => {
-    // add the correct file name
-    t.is(typeof fileMap['pages/index.md'], 'object')
-    t.is(fileMap['pages/index.md'].layout, 'home.hbs')
-    t.is(fileMap['pages/index.md'].contents.toString(), 'Home Page Content')
+  processor.createFilesFromEntries(options)
+    .then(fileMap => {
+      // add the correct file name
+      t.is(typeof fileMap['pages/index.md'], 'object')
+      t.is(fileMap['pages/index.md'].layout, 'home.html')
+      t.is(fileMap['pages/index.md'].contents.toString(), 'Home Page Content')
 
-    t.end()
-  })
+      t.end()
+    })
 })

--- a/lib/processor.spec.js
+++ b/lib/processor.spec.js
@@ -274,3 +274,57 @@ test('processor.getCommonContentForSpace - load a set of common content', t => {
     t.is(fileMap['turnip.html'].common.doublets, entriesToBeReturned)
   })
 })
+
+test.cb('processor.processFile - transform file meta into a new file', t => {
+  const options = {
+    access_token: 'global-bar',
+    host: 'global-baz',
+    space_id: 'global-foo',
+    entry_key: '_key',
+    entry_extension: 'md'
+  }
+
+  const entriesToBeReturned = [
+    {
+      sys: {
+        id: 'bazinga',
+        contentType: {
+          sys: {
+            id: 'boing'
+          }
+        }
+      },
+      fields: {
+        name: 'John Doe',
+        _key: 'pages/index',
+        layout: 'home.hbs',
+        contents: 'Home Page Content'
+      }
+    }
+  ]
+
+  const processor = proxyquire(
+    './processor',
+    {
+      contentful: {
+        createClient: function () {
+          return {
+            getEntries: function () {
+              return new Promise(resolve => resolve({items: entriesToBeReturned}))
+            }
+          }
+        }
+      }
+    }
+  )
+
+  processor.processFile({ contentful: {}, _fileName: 'turnip.html' }, options)
+  .then(fileMap => {
+    // add the correct file name
+    t.is(typeof fileMap['pages/index.md'], 'object')
+    t.is(fileMap['pages/index.md'].layout, 'home.hbs')
+    t.is(fileMap['pages/index.md'].contents.toString(), 'Home Page Content')
+
+    t.end()
+  })
+})

--- a/lib/util.js
+++ b/lib/util.js
@@ -80,7 +80,11 @@ function getFileName (entry, fileOptions, globalOptions) {
 
   const extension = fileOptions.use_template_extension
                     ? fileOptions.entry_template.split('.').slice(1).pop()
-                    : 'html'
+                    : (
+                      globalOptions.entry_extension
+                      ? globalOptions.entry_extension
+                      : 'html'
+                    )
 
   let renderedPattern = `${entry.sys.contentType.sys.id}-${entry.sys.id}`
 
@@ -99,6 +103,11 @@ function getFileName (entry, fileOptions, globalOptions) {
 
   if (fileOptions.create_permalinks) {
     return `${renderedPattern}/index.${extension}`
+  }
+
+  // use the entry key described from the global `key` option
+  if (globalOptions.entry_key && typeof globalOptions.entry_key === 'string') {
+    return `${entry.fields[globalOptions.entry_key]}.${extension}`
   }
 
   return `${renderedPattern}.${extension}`

--- a/lib/util.js
+++ b/lib/util.js
@@ -106,7 +106,7 @@ function getFileName (entry, fileOptions, globalOptions) {
   }
 
   // use the entry key described from the global `key` option
-  if (globalOptions.entry_key && typeof globalOptions.entry_key === 'string') {
+  if (globalOptions.entry_key && typeof globalOptions.entry_key === 'string' && entry.fields[globalOptions.entry_key]) {
     return `${entry.fields[globalOptions.entry_key]}.${extension}`
   }
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "handlebars": "^4.0.5",
     "metalsmith": "^2.2.0",
     "metalsmith-layouts": "^1.6.5",
+    "metalsmith-markdown": "0.2.1",
     "nock": "9.0.2",
     "nyc": "^8.1.0",
     "proxyquire": "^1.7.10",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "handlebars": "^4.0.5",
     "metalsmith": "^2.2.0",
     "metalsmith-layouts": "^1.6.5",
+    "nock": "9.0.2",
     "nyc": "^8.1.0",
     "proxyquire": "^1.7.10",
     "semantic-release": "^4.3.5"

--- a/test/entry_key_build/pages/index.html
+++ b/test/entry_key_build/pages/index.html
@@ -1,0 +1,1 @@
+<p>Home Page Content</p>

--- a/test/fixtures/res.js
+++ b/test/fixtures/res.js
@@ -1,0 +1,28 @@
+module.exports = {
+  items: [{
+    sys: {
+      id: '1asN98Ph3mUiCYIYiiqwko',
+      space: 'w7sdyslol3fu',
+      type: 'Entry',
+      createdAt: '2015-01-30T12:45:03.282Z',
+      updatedAt: '2015-01-30T13:01:37.936Z',
+      revision: 2,
+      locale: 'en-US',
+      contentType: {
+        sys: {
+          id: 'boing'
+        }
+      }
+    },
+    fields: {
+      name: 'John Doe',
+      _key: 'pages/index',
+      layout: 'post.html',
+      contents: 'Home Page Content',
+      category: [],
+      tags: [],
+      date: '1865-11-26',
+      comments: false
+    }
+  }]
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -34,15 +34,21 @@ test__posts__ordered-POSTS-CONTENT-ORDERED\n`,
  * @return {Object}       metalsmith instance
  *
  */
-function createMetalsmith (config = {}) {
+function createMetalsmith (config = {}, markdown) {
   const metalsmith = new Metalsmith(__dirname)
 
   metalsmith.use(
     require('..')(config)
   )
-  metalsmith.use(
-    require('metalsmith-layouts')({ engine: 'handlebars' })
-  )
+  if (markdown) {
+    metalsmith.use(
+      require('metalsmith-markdown')()
+    )
+  } else {
+    metalsmith.use(
+      require('metalsmith-layouts')({ engine: 'handlebars' })
+    )
+  }
 
   metalsmith.source(config.src || 'src')
   metalsmith.destination(config.dest || 'build')
@@ -204,7 +210,7 @@ test.serial.cb('e2e - it should render all templates properly', t => {
   })
 })
 
-test.serial.cb('e2e - it should render file from contentful', t => {
+test.serial.cb.only('e2e - it should render file from contentful', t => {
   /* eslint camelcase: 0 */
   const space_id = 'w7sdyslol3fu'
   const access_token = 'baa905fc9cbfab17b1bc0b556a7e17a3e783a2068c9fd6ccf74ba09331357182'
@@ -229,7 +235,7 @@ test.serial.cb('e2e - it should render file from contentful', t => {
         return `aldente-${slug(entry.fields.title)}.html`
       }
     }
-  })
+  }, true)
 
   metalsmith.build(error => {
     if (error) {
@@ -244,6 +250,11 @@ test.serial.cb('e2e - it should render file from contentful', t => {
     t.is(
       fs.readdirSync(`${__dirname}/entry_key_build/`)[0],
       'pages'
+    )
+
+    t.is(
+      fs.readFileSync(`${__dirname}/entry_key_build/pages/index.html`, { encoding: 'utf8' }),
+      '<p>Home Page Content</p>\n'
     )
 
     t.end()

--- a/test/layouts/home.html
+++ b/test/layouts/home.html
@@ -1,0 +1,1 @@
+{{data.fields.contents}}


### PR DESCRIPTION
With this PR, users can now add `entry_key` and `entry_extension` to their global settings and transform entries from Contentful into files within Metalsmith. The files are created from the `entry_key` property and must be referenced properly to the path of the file. The file with have the `entry_extension` as the extension to the file. The files will add contents as a Buffer for other Metalsmith plugins. 

**Example:**

```
... // global settings
entry_key: '_key'
entry_extension: 'md'
```

An entry in Contentful with properties:
```
_key: pages/index
contents: '# My Home Page'
```

Output:
```
build/pages/index.html => <h1>My Home Page</h1>
```
