### PR TITLE
add locale and include to entries query

### DIFF
--- a/docs/source-file-settings.md
+++ b/docs/source-file-settings.md
@@ -225,6 +225,23 @@ Post that include rabbits are...
 
 If you want to learn more about the filter syntax, check out the [Content Delivery API documentation](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters).
 
+### `include` *(optional)*
+
+**Retrieval of linked items (maximum of 10 levels)**
+
+```markdown
+---
+title: Posts with up to 10 levels of linked items retrieved
+contentful:
+  content_type: post
+  include: 10
+layout: posts.html
+---
+posts with retrieved links are...
+```
+
+If you want to learn more about retrieval of linked items, check out the [Content Delivery API documentation](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/links).
+
 ### `limit` *(optional)*
 
 **Limit the entries before rendering to one or multiple files**
@@ -241,6 +258,23 @@ layout: posts.html
 ```
 
 If you want to learn more about limits, check out the [Content Delivery API documentation](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/limit).
+
+### `locale` *(optional)*
+
+**Specify the locale used for entries**
+
+```markdown
+---
+title: Posts in Traditional Chinese Hong Kong
+contentful:
+  content_type: post
+  locale: zh-Hant-HK
+layout: posts.html
+---
+posts in Traditional Chinese Hong Kong are...
+```
+
+If you want to learn more about locales, check out the [Content Delivery API documentation](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/localization).
 
 ### `order` *(optional)*
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,7 +5,7 @@ const pick = require('lodash.pick')
 const template = require('lodash.template')
 const slug = require('slug-component')
 
-const propertiesToPickEasily = ['limit', 'order']
+const propertiesToPickEasily = ['locale', 'include', 'limit', 'order']
 const notFoundKey = '__not-available__'
 const notFoundRegex = new RegExp(notFoundKey)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "contentful-metalsmith",
-  "version": "0.8.1",
   "description": "A Metalsmith's plugin to get content from Contentful",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "contentful-metalsmith",
+  "version": "0.8.1",
   "description": "A Metalsmith's plugin to get content from Contentful",
   "main": "index.js",
   "repository": {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -14,8 +14,12 @@ test__posts__permalinks-POSTS-CONTENT-PERMALINKS\n`,
 test__posts__extentsion-POSTS-CONTENT-EXTENSION\n`,
   postsFiltered: `Down the Rabbit Hole
 test__posts__filtered-POSTS-CONTENT-FILTERED\n`,
+  postsInclude: `Down the Rabbit HoleSeven Tips From Ernest Hemingway on How to Write Fiction
+test__posts-POSTS-INCLUDE\n`,
   postsLimited: `Down the Rabbit Hole
 test__posts__limited-POSTS-CONTENT-LIMITED\n`,
+  postsLocale: `Down the Rabbit HoleSeven Tips From Ernest Hemingway on How to Write Fiction
+test__posts__locale-POSTS-CONTENT-LOCALE\n`,
   postsOrdered: `Seven Tips From Ernest Hemingway on How to Write FictionDown the Rabbit Hole
 test__posts__ordered-POSTS-CONTENT-ORDERED\n`,
   posts: {
@@ -100,11 +104,27 @@ test.serial.cb('e2e - it should render all templates properly', t => {
     )
 
     //
+    // render include posts
+    //
+    t.is(
+      fs.readFileSync(`${__dirname}/build/posts-include.html`, { encoding: 'utf8' }),
+      expectedResults.postsInclude
+    )
+
+    //
     // render limited posts
     //
     t.is(
       fs.readFileSync(`${__dirname}/build/posts-limited.html`, { encoding: 'utf8' }),
       expectedResults.postsLimited
+    )
+
+    //
+    // render locale posts
+    //
+    t.is(
+      fs.readFileSync(`${__dirname}/build/posts-locale.html`, { encoding: 'utf8' }),
+      expectedResults.postsLocale
     )
 
     //

--- a/test/src/posts-include.html
+++ b/test/src/posts-include.html
@@ -1,0 +1,8 @@
+---
+title: test__posts
+contentful:
+  content_type: 2wKn6yEnZewu2SCCkus4as
+  include: 0
+layout: posts.html
+---
+POSTS-INCLUDE

--- a/test/src/posts-locale.html
+++ b/test/src/posts-locale.html
@@ -1,0 +1,8 @@
+---
+title: test__posts__locale
+contentful:
+  content_type: 2wKn6yEnZewu2SCCkus4as
+  locale: en-US
+layout: posts.html
+---
+POSTS-CONTENT-LOCALE


### PR DESCRIPTION
this was critical for us to use this library as we have mostly multi-language websites.

We can now add the following to the source files in metalsmith:

contentful:
    entry_id: 6wGld8QQEMyuqcGGgmoQWO
    locale: en-US
    include: 10